### PR TITLE
一度再生された曲が再度選曲されないよう変更

### DIFF
--- a/src/portfolio1/app/Http/Controllers/SongController.php
+++ b/src/portfolio1/app/Http/Controllers/SongController.php
@@ -11,19 +11,26 @@ class SongController extends Controller
 {
     //曲の再生完了時・nextボタン押下時，指定された条件に合致する曲の中で
     //再生数が最も少ない曲のデータを取得する
-    public function next($selected_genre_id){
+    public function next(Request $request){
 
         $next_song =  Song::select('songs.*', 'genre_master_song.genre_master_id', 'users.name', 'users.link')
                             ->join('genre_master_song', 'songs.id', '=', 'genre_master_song.song_id')
                             ->join('users' , 'user_id' , '=', 'users.id')
-                            ->where('genre_master_id', $selected_genre_id)
+                            ->where('genre_master_id', '=', $request->selected_genre_id)
+                            ->whereNotIn('songs.id', $request->except)
                             ->get()
                             ->sortBy('plays')
                             ->first();
 
         //再生数の更新
-        $next_song->plays++;
-        $next_song->save();
+        if(isset($next_song)){
+            $next_song->plays++;
+            $next_song->save();
+        }
+        else{
+            $next_song = null;
+        }
+
 
         return $next_song;
     }

--- a/src/portfolio1/resources/views/home.blade.php
+++ b/src/portfolio1/resources/views/home.blade.php
@@ -32,6 +32,9 @@
                         <li>
                             次の曲ボタン<span class="btn btn-primary"><i class="fas fa-fast-forward fa-1x"></i></span>をクリックすると，即座に次の楽曲が再生されます．
                         </li>
+                        <li>
+                            一度再生された曲が再度選曲されることはありません．再度選曲されるようにするためには，<button class="btn btn-success">再生履歴を消去する</button>をクリックしてください．
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/src/portfolio1/resources/views/welcome.blade.php
+++ b/src/portfolio1/resources/views/welcome.blade.php
@@ -132,7 +132,14 @@
                 </div>
                 
                 <div class="card-body">
-                    サンプル用のデータとして，BGMer様(<a href="https://bgmer.net/">https://bgmer.net/</a>)の楽曲を利用しています．
+                    <ul>
+                        <li>
+                            サンプル用のデータとして，BGMer様(<a href="https://bgmer.net/">https://bgmer.net/</a>)の楽曲を利用しています．
+                        </li>
+                        <li>
+                            ガイド音声として，音読さん<a href="https://ondoku3.com">(https://ondoku3.com)</a>を利用しています．
+                        </li>
+                    </ul>
                 </div>
             </div>
         </div>

--- a/src/portfolio1/routes/web.php
+++ b/src/portfolio1/routes/web.php
@@ -31,7 +31,7 @@ Route::get('/upload' , [App\Http\Controllers\UploadController::class, 'index'])-
 Route::post('/upload', [App\Http\Controllers\UploadController::class, 'upload'])->middleware('auth');
 
 //曲データの読み込み
-Route::get('/next/{selected_genre_id}', 'App\Http\Controllers\SongController@next'); //nextボタン押下時・再生の完了時
+Route::get('/next', 'App\Http\Controllers\SongController@next'); //nextボタン押下時・再生の完了時
 Route::get('/mounted', 'App\Http\Controllers\SongController@mounted'); //ページがロードされた時
 
 //全てのジャンル名の読み込み


### PR DESCRIPTION
再生された曲のidをブラウザ側で記憶し，選曲の際にそれらのidの曲を除外するように変更．
加えて，それらの再生履歴を消去する機能を追加．